### PR TITLE
Strip extension ids

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.0a3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Strip extension ids.
+  [odelaere]
 
 
 1.0a2 (2021-08-17)

--- a/src/collective/big/bang/big.py
+++ b/src/collective/big/bang/big.py
@@ -41,10 +41,13 @@ def bang(event):
 
         # install Plone site
         extension_ids = tuple(
-            os.getenv(
-                "PLONE_EXTENSION_IDS",
-                "plone.app.caching:default,plonetheme.barceloneta:default",
-            ).split(",")
+            [
+                extension.strip()
+                for extension in os.getenv(
+                    "PLONE_EXTENSION_IDS",
+                    "plone.app.caching:default, plonetheme.barceloneta:default",
+                ).split(",")
+            ]
         )
 
         default_language = os.getenv("DEFAULT_LANGUAGE", "en")


### PR DESCRIPTION
In case you have a space char after each coma.
ex : `"plone.app.caching:default, plonetheme.barceloneta:default"`

Otherwise the profile is not found and _bang_ fails

This also adds readability.